### PR TITLE
Upgrade journal

### DIFF
--- a/install/postgres-journaling
+++ b/install/postgres-journaling
@@ -46,7 +46,7 @@ else
                    :host => opts[:host],
                    :port => opts[:port])
     query = psql.in_schema(schema_name) do
-      File.read("scripts/postgres/install.sql").gsub("journal.", "#{schema_name}.")
+      File.read("scripts/postgres/install.sql").gsub("journal.", "#{schema_name}.").gsub("'journal'", "'#{schema_name}'")
     end
     success = psql.execute(query)
     tell "Journaling installed successfully into the #{schema_name} schema." if success

--- a/scripts/postgres/install.sql
+++ b/scripts/postgres/install.sql
@@ -1,13 +1,15 @@
 create or replace function journal.refresh_journal_trigger(
-  p_source_schema_name in varchar, p_source_table_name in varchar,
-  p_target_schema_name in varchar, p_target_table_name in varchar
+  p_source_schema_name in varchar,
+  p_source_table_name in varchar,
+  p_target_schema_name in varchar = 'journal',
+  p_target_table_name in varchar = null
 ) returns varchar language plpgsql as $$
 declare
   v_insert_trigger_name text;
   v_delete_trigger_name text;
 begin
-  v_insert_trigger_name := journal.refresh_journal_insert_trigger(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
-  v_delete_trigger_name := journal.refresh_journal_delete_trigger(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
+  v_insert_trigger_name := journal.refresh_journal_insert_trigger(p_source_schema_name, p_source_table_name, p_target_schema_name, coalesce(p_target_table_name, p_source_table_name));
+  v_delete_trigger_name := journal.refresh_journal_delete_trigger(p_source_schema_name, p_source_table_name, p_target_schema_name, coalesce(p_target_table_name, p_source_table_name));
 
   return v_insert_trigger_name || ' ' || v_delete_trigger_name;
 end;
@@ -22,8 +24,8 @@ declare
   v_journal_name text;
   v_source_name text;
   v_trigger_name text;
-  v_first boolean;
   v_sql text;
+  v_target_sql text;
 begin
   v_journal_name = p_target_schema_name || '.' || p_target_table_name;
   v_source_name = p_source_schema_name || '.' || p_source_table_name;
@@ -31,21 +33,15 @@ begin
   -- create the function
   v_sql = 'create or replace function ' || v_journal_name || '_delete() returns trigger language plpgsql as ''';
   v_sql := v_sql || ' begin ';
-  v_sql := v_sql || '  insert into ' || v_journal_name || ' (';
+  v_sql := v_sql || '  insert into ' || v_journal_name || ' (journal_operation';
+  v_target_sql = 'TG_OP';
 
-  v_first = true;
   for row in (select column_name from information_schema.columns where table_schema = p_source_schema_name and table_name = p_source_table_name order by ordinal_position) loop
-
-    if (v_first) then
-      v_first := false;
-    else
-      v_sql := v_sql || ', ';
-    end if;
-    v_sql := v_sql || row.column_name;
-
+    v_sql := v_sql || ', ' || row.column_name;
+    v_target_sql := v_target_sql || ', old.' || row.column_name;
   end loop;
 
-  v_sql := v_sql || ', journal_operation) values (old.*, TG_OP); ';
+  v_sql := v_sql || ') values (TG_OP' || v_target_sql || '); ';
   v_sql := v_sql || ' return null; end; ''';
 
   execute v_sql;
@@ -73,6 +69,8 @@ declare
   v_trigger_name text;
   v_first boolean;
   v_sql text;
+  v_target_sql text;
+  v_name text;
 begin
   v_journal_name = p_target_schema_name || '.' || p_target_table_name;
   v_source_name = p_source_schema_name || '.' || p_source_table_name;
@@ -80,21 +78,22 @@ begin
   -- create the function
   v_sql = 'create or replace function ' || v_journal_name || '_insert() returns trigger language plpgsql as ''';
   v_sql := v_sql || ' begin ';
-  v_sql := v_sql || '  insert into ' || v_journal_name || ' (';
 
-  v_first = true;
-  for row in (select column_name from information_schema.columns where table_schema = p_source_schema_name and table_name = p_source_table_name order by ordinal_position) loop
-
-    if (v_first) then
-      v_first := false;
-    else
-      v_sql := v_sql || ', ';
-    end if;
-    v_sql := v_sql || row.column_name;
-
+  for v_name in (select * from journal.primary_key_columns(p_source_schema_name, p_source_table_name)) loop
+    v_sql := v_sql || '  if (TG_OP=''''UPDATE'''' and (old.' || v_name || ' != new.' || v_name || ')) then';
+    v_sql := v_sql || '    raise exception ''''Table[' || v_source_name || '] is journaled. Updates to primary key column[' || v_name || '] are not supported as this would make it impossible to follow the history of this row in the journal table[' || v_journal_name || ']'''';';
+    v_sql := v_sql || '  end if;';
   end loop;
 
-  v_sql := v_sql || ', journal_operation) values (new.*, TG_OP); ';
+  v_sql := v_sql || '  insert into ' || v_journal_name || ' (journal_operation';
+  v_target_sql = 'TG_OP';
+
+  for row in (select column_name from information_schema.columns where table_schema = p_source_schema_name and table_name = p_source_table_name order by ordinal_position) loop
+    v_sql := v_sql || ', ' || row.column_name;
+    v_target_sql := v_target_sql || ', new.' || row.column_name;
+  end loop;
+
+  v_sql := v_sql || ') values (' || v_target_sql || '); ';
   v_sql := v_sql || ' return null; end; ''';
 
   execute v_sql;
@@ -117,9 +116,61 @@ create or replace function journal.get_data_type_string(
 begin
   return case p_column.data_type
     when 'numeric' then p_column.data_type || '(' || p_column.numeric_precision_radix::varchar || ',' || p_column.numeric_scale::varchar || ')'
-    when 'character' then p_column.data_type || '(' || p_column.character_maximum_length::varchar || ')'
+    when 'character' then 'text'
+    when 'character varying' then 'text'
+    when '"char"' then 'text'
     else p_column.data_type
     end;
+end;
+$$;
+
+create or replace function journal.primary_key_columns(
+  p_schema_name in varchar,
+  p_table_name in varchar
+) returns setof text language plpgsql AS $$
+declare
+  row record;
+begin
+  for row in (
+      select key_column_usage.column_name
+        from information_schema.table_constraints
+        join information_schema.key_column_usage
+             on key_column_usage.table_name = table_constraints.table_name
+            and key_column_usage.table_schema = table_constraints.table_schema
+            and key_column_usage.constraint_name = table_constraints.constraint_name
+       where table_constraints.constraint_type = 'PRIMARY KEY'
+         and table_constraints.table_schema = p_schema_name
+         and table_constraints.table_name = p_table_name
+       order by coalesce(key_column_usage.position_in_unique_constraint, 0),
+                coalesce(key_column_usage.ordinal_position, 0),
+                key_column_usage.column_name
+  ) loop
+    return next row.column_name;
+  end loop;
+end;
+$$;
+
+
+create or replace function journal.add_primary_key_data(
+  p_source_schema_name in varchar, p_source_table_name in varchar,
+  p_target_schema_name in varchar, p_target_table_name in varchar
+) returns void language plpgsql as $$
+declare
+  v_name text;
+  v_columns character varying := '';
+begin
+  for v_name in (select * from journal.primary_key_columns(p_source_schema_name, p_source_table_name)) loop
+    if v_columns != '' then
+      v_columns := v_columns || ', ';
+    end if;
+    v_columns := v_columns || v_name;
+    execute 'alter table ' || p_target_schema_name || '.' || p_target_table_name || ' alter column ' || v_name || ' set not null';
+  end loop;
+
+  if v_columns != '' then
+    execute 'create index on ' || p_target_schema_name || '.' || p_target_table_name || '(' || v_columns || ')';
+  end if;
+
 end;
 $$;
 
@@ -137,7 +188,8 @@ begin
     for row in (select column_name, journal.get_data_type_string(information_schema.columns.*) as data_type from information_schema.columns where table_schema = p_source_schema_name and table_name = p_source_table_name order by ordinal_position) loop
 
       -- NB: Specifically choosing to not drop deleted columns from the journal table, to preserve the data.
-      -- There are no constraints on the journaling table columns anyway, so leaving it populated with null will be fine.
+      -- There are no constraints (other than not null on primary key columns) on the journaling table
+      -- columns anyway, so leaving it populated with null will be fine.
       select journal.get_data_type_string(information_schema.columns.*) into v_data_type from information_schema.columns where table_schema = p_target_schema_name and table_name = p_target_table_name and column_name = row.column_name;
       if not found then
         execute 'alter table ' || v_journal_name || ' add ' || row.column_name || ' ' || row.data_type;
@@ -152,12 +204,11 @@ begin
     execute 'alter table ' || v_journal_name || ' add journal_operation text not null ';
     execute 'alter table ' || v_journal_name || ' add journal_id bigserial primary key ';
     execute 'comment on table ' || v_journal_name || ' is ''Created by plsql function refresh_journaling to shadow all inserts and updates on the table ' || p_source_schema_name || '.' || p_source_table_name || '''';
-    execute 'create index ' || p_target_table_name || '_id_idx on ' || v_journal_name || '(id)';
-
+    perform journal.add_primary_key_data(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
   end if;
 
   perform journal.refresh_journal_trigger(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
-
+  
   return v_journal_name;
 
 end;

--- a/scripts/postgres/install.sql
+++ b/scripts/postgres/install.sql
@@ -41,7 +41,7 @@ begin
     v_target_sql := v_target_sql || ', old.' || row.column_name;
   end loop;
 
-  v_sql := v_sql || ') values (TG_OP' || v_target_sql || '); ';
+  v_sql := v_sql || ') values (' || v_target_sql || '); ';
   v_sql := v_sql || ' return null; end; ''';
 
   execute v_sql;


### PR DESCRIPTION
  - Remove assumption on an 'id' column. Instead, query the source
    table for all of the columns in its primary key index, if one
    exists, and then create an index on the same set of columns on the
    journal table. This fixes https://github.com/gilt/db-journaling/issues/12

  - remove old.*, new.* and replace with explicit column lists. This
    prevents the runtime error when adding a column to the source
    table which we think is a better failure mode.

  - add defaults for parameters in the journal.refresh_journal_trigger function

    This allows for the default case of using the same table name in
    the journal schema to omit the target schema and table names

  - for columns of character data types, use the type 'text' in the journal
    tables. This avoids complications around sizing / resizing of these fields.
    Convert 'character', 'character varying', and '"char"' types.
    Fixes https://github.com/gilt/db-journaling/issues/1

  - When creating journal table, set columns that are part of the
    primary key to not null. This will cause potential errors if you
    alter the source table's primary key - but we feel this is rarely
    needed and in those cases we can expect the journal to be
    recreated.

  - add a check to prevent changes to primary key values. The primary
    key values are the only pieces of data we have in the journal to
    tie the records together. If you change the value of a primary key
    column, you lose the ability to read the journal coherently. Thus
    we add assertions into the trigger that the primary key values are
    unchanged.

    An example of the error message a user will receive in this case:

    ERROR: Table[public.users] is journaled. Updates to primary key
    column[guid] are not supported as this would make it impossible to
    follow the history of this row in the journal table[journal.users]