### PR TITLE
Have numeric fields just be arbitrary numeric

### DIFF
--- a/scripts/postgres/install.sql
+++ b/scripts/postgres/install.sql
@@ -115,7 +115,6 @@ create or replace function journal.get_data_type_string(
 ) returns varchar language plpgsql as $$
 begin
   return case p_column.data_type
-    when 'numeric' then p_column.data_type || '(' || p_column.numeric_precision_radix::varchar || ',' || p_column.numeric_scale::varchar || ')'
     when 'character' then 'text'
     when 'character varying' then 'text'
     when '"char"' then 'text'


### PR DESCRIPTION
Postgres allows you to have an unspecified scale, which becomes null and
breaks this line of code.

See "Arbitrary Precision Numbers" at
https://www.postgresql.org/docs/9.3/static/datatype-numeric.html

Similar to
https://github.com/gilt/db-journaling/commit/8632a2fe06783d90474dea95935e5d465c53f618
Rather than play around with it, just allow the journal to be arbitrary